### PR TITLE
optional content_id

### DIFF
--- a/app/Http/Controllers/Auth/LTILaunchController.php
+++ b/app/Http/Controllers/Auth/LTILaunchController.php
@@ -25,9 +25,10 @@ class LTILaunchController extends Controller
 
 
     private function getRedirect($url, $user_id, $content_id) {
-        $url .= (strpos($url, '?') === false ? '?' : '&').
-            'user_id='.urlencode($user_id).
-            'content_id='.urlencode($content_id);
+        $url .= (strpos($url, '?') === false ? '?' : '&').'user_id='.urlencode($user_id);
+        if($content_id !== null) {
+            $url .= 'content_id='.urlencode($content_id);
+        }
         return redirect($url, 303);
     }
 

--- a/app/LoginModule/LTI/Tool/LTI_Tool_Provider.php
+++ b/app/LoginModule/LTI/Tool/LTI_Tool_Provider.php
@@ -780,7 +780,7 @@ EOD;
           $this->resource_link->lti_context_id = trim($_POST['context_id']);
         }
         $this->resource_link->lti_resource_id = trim($_POST['resource_link_id']);
-        $this->resource_link->content_id = trim($_POST['content_id']);
+        $this->resource_link->content_id = isset($_POST['content_id']) ? trim($_POST['content_id']) : null;
         $title = '';
         if (isset($_POST['context_title'])) {
           $title = trim($_POST['context_title']);


### PR DESCRIPTION
content_id is still required in sendResult, but I am not sure how to make it optional there.
also old lti/entry and lti/send_result are still available, content_id not used there