### PR TITLE
Restore call to RolesAndPermissionsSeeder in DatabaseSeeder

### DIFF
--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -11,7 +11,7 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-        //$this->call(RolesAndPermissionsSeeder::class);
+        $this->call(RolesAndPermissionsSeeder::class);
         $this->call(UsersSeeder::class);
         $this->call(ClientsSeeder::class);
         $this->call(OfficialDomainsSeeder::class);


### PR DESCRIPTION
Restore call to RolesAndPermissionsSeeder in DatabaseSeeder as UsersSeeder fails otherwise.